### PR TITLE
Add polling interval description

### DIFF
--- a/source/_integrations/fastdotcom.markdown
+++ b/source/_integrations/fastdotcom.markdown
@@ -31,6 +31,17 @@ By default, a speed test will be run every hour. The user can manually run a spe
 
 {% include integrations/config_flow.md %}
 
+## Polling interval
+
+By default, the integration will ping the device every 30 seconds. 
+If you wish to do a ping at a different interval, you can disable the automatic refresh in the integration's system options (Enable polling for updates) and create your own automation with your desired frequency.
+
+For more detailed steps on how to define a custom interval, follow the procedure below.
+
+### Defining a custom polling interval
+
+{% include common-tasks/define_custom_polling.md %}
+
 ## Notes
 
 - When running on Raspberry Pi 3 or older, the maximum speed is limited by its 100 Mbit/s LAN adapter.

--- a/source/_integrations/fastdotcom.markdown
+++ b/source/_integrations/fastdotcom.markdown
@@ -33,8 +33,8 @@ By default, a speed test will be run every hour. The user can manually run a spe
 
 ## Polling interval
 
-By default, the integration will ping the device every 30 seconds. 
-If you wish to do a ping at a different interval, you can disable the automatic refresh in the integration's system options (Enable polling for updates) and create your own automation with your desired frequency.
+By default, the integration will do a speed test via Fast.com ever hour. 
+If you wish to do at a different interval, you can disable the automatic refresh in the integration's system options (Enable polling for updates) and create your own automation with your desired frequency.
 
 For more detailed steps on how to define a custom interval, follow the procedure below.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Expand the documentation in a good fashion to instruct peolpe how manually add a custom polling.
It has a dependency on https://github.com/home-assistant/core/pull/104839, if this is released the interval polling truly comes to affect.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
